### PR TITLE
Fix addon icon

### DIFF
--- a/src/plugin.video.icdrama/addon.xml
+++ b/src/plugin.video.icdrama/addon.xml
@@ -16,5 +16,8 @@
     <disclaimer>This addon is not affiliated with icdrama.se</disclaimer>
     <platform>all</platform>
     <license>MIT License</license>
+    <assets>
+        <icon>icon.png</icon>
+    </assets>
   </extension>
 </addon>


### PR DESCRIPTION
Kodi v19 uses the assets metadata to configure the addon's icon.