### PR TITLE
Add new ICDrama site hosts to fix breakage

### DIFF
--- a/addons.xml
+++ b/addons.xml
@@ -2,7 +2,7 @@
 <addons>
 
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.icdrama" version="2.3.2" name="Icdrama" provider-name="aznhusband, dumbo0001, s_h, boleanly, mugol, General-Meow, cthlo, soraxas, andya4">
+<addon id="plugin.video.icdrama" version="2.3.3" name="Icdrama" provider-name="aznhusband, dumbo0001, s_h, boleanly, mugol, General-Meow, cthlo, soraxas, andya4">
   <requires>
     <import addon="script.module.html5lib" version="0.999.0"/>
     <import addon="script.module.beautifulsoup4" version="4.3.2"/>

--- a/src/plugin.video.icdrama/addon.xml
+++ b/src/plugin.video.icdrama/addon.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<addon id="plugin.video.icdrama" version="2.3.2" name="Icdrama" provider-name="aznhusband, dumbo0001, s_h, boleanly, mugol, General-Meow, cthlo, soraxas, andya4">
+<addon id="plugin.video.icdrama" version="2.3.3" name="Icdrama" provider-name="aznhusband, dumbo0001, s_h, boleanly, mugol, General-Meow, cthlo, soraxas, andya4">
   <requires>
     <import addon="script.module.html5lib" version="0.999.0"/>
     <import addon="script.module.beautifulsoup4" version="4.3.2"/>

--- a/src/plugin.video.icdrama/lib/config.py
+++ b/src/plugin.video.icdrama/lib/config.py
@@ -3,7 +3,7 @@ from urllib.parse import urljoin
 from lib.common import diritem, action_url, profile_dir
 
 base_url = 'http://icdrama.to'
-domains = ['hkdrama.to', 'adrama.to', 'icdrama.to', 'icdrama.se']
+domains = ['hkdrama.to', 'adrama.to', 'icdrama.to', 'icdrama.se', 'adramas.se']
 cache_file = os.path.join(profile_dir, 'cache.pickle')
 store_file = os.path.join(profile_dir, 'store.pickle')
 

--- a/src/plugin.video.icdrama/lib/resolvers/hdplay.py
+++ b/src/plugin.video.icdrama/lib/resolvers/hdplay.py
@@ -14,8 +14,8 @@ from .. import common as cmn
 
 class HdPlay(ResolveUrl):
     name = 'HDplay'
-    domains = [ 'hdplay.se']
-    pattern = '(?://|\.)(hdplay\.se)/(.+)'
+    domains = [ 'hdplay.se', 'drive.adramas.se']
+    pattern = '(?://|\.)(hdplay\.se|drive\.adramas\.se)/(.+)'
 
 
     def __init__(self):
@@ -25,6 +25,7 @@ class HdPlay(ResolveUrl):
 
     def get_media_url(self, host, media_id):
         url = self.get_url(host, media_id)
+        # xbmc.log(str([host, media_id, url]), xbmc.LOGERROR)
         response = requests.get(url, headers=self.headers)
 
         if response.status_code == 200:


### PR DESCRIPTION
They seemed to internally have shuffled things around to new hosts with the introduction of the "FAST" mirror, which does not work with this version. But HLS works.